### PR TITLE
Update TaskSchedulingService.java

### DIFF
--- a/api/src/main/java/ca/bc/gov/educ/api/batchgraduation/service/TaskSchedulingService.java
+++ b/api/src/main/java/ca/bc/gov/educ/api/batchgraduation/service/TaskSchedulingService.java
@@ -45,6 +45,10 @@ public class TaskSchedulingService {
             scheduledTask.cancel(true);
             jobsMap.remove(jobId);
         }
+        Optional<UserScheduledJobsEntity> optional = userScheduledJobsRepository.findById(jobId);
+        if (optional.isPresent()) {
+            userScheduledJobsRepository.delete(optional.get());
+        }
         logger.info("Task removed {}",jobId);
     }
 


### PR DESCRIPTION
Fixed the issue that deleting the user scheduled job is only done for the task scheduler, and the actual record in database is not deleted.